### PR TITLE
Fix: Resolve Vercel TypeScript build errors and cleanup config

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "socket.io-client": "^4.7.2",
     "axios": "^1.6.0",
     "uuid": "^9.0.1",
-    "@vercel/kv": "^0.2.0"
+    "@vercel/kv": "latest"
   },
   "devDependencies": {
     "@types/node": "^20.8.10",

--- a/frontend/src/app/api/search-status/[id]/route.ts
+++ b/frontend/src/app/api/search-status/[id]/route.ts
@@ -32,7 +32,7 @@ export async function GET(
     // 如果Vercel KV可用，优先从KV获取数据
     if (kv) {
       try {
-        searchData = await kv.get<any>(`search:${searchId}`);
+        searchData = await kv.get(`search:${searchId}`) as any;
       } catch (kvError) {
         console.error('Error retrieving data from KV:', kvError);
         // 回退到内存存储

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -2,16 +2,5 @@
   "buildCommand": "npm run build",
   "framework": "nextjs",
   "installCommand": "npm install",
-  "outputDirectory": ".next",
-  "env": {
-    "REPOSITORY": {
-      "description": "GitHub仓库，格式为：用户名/仓库名"
-    },
-    "GITHUB_TOKEN": {
-      "description": "GitHub个人访问令牌，需要有workflow权限"
-    }
-  },
-  "buildEnvironment": {
-    "NODE_VERSION": "18.x"
-  }
+  "outputDirectory": ".next"
 }


### PR DESCRIPTION
This commit addresses several issues that were causing your Vercel deployment to fail during the build process:

1.  **Adjust kv.get usage:** I modified the call to `@vercel/kv`'s `get` method in `frontend/src/app/api/search-status/[id]/route.ts` from `kv.get<any>(...)` to `kv.get(...) as any;` to resolve a TypeScript error: "Untyped function calls may not accept type arguments."

2.  **Add tsconfig.json for frontend:** A `tsconfig.json` file has been added to the `frontend/` directory with standard Next.js settings. This ensures consistent TypeScript compilation behavior and prevents Vercel from auto-generating a potentially incompatible configuration.

3.  **Clean up frontend/vercel.json:** I removed the `buildEnvironment` and `env` keys from `frontend/vercel.json`. These settings are better managed directly in the Vercel project dashboard (Node.js version and environment variables, respectively).

4.  **Update @vercel/kv (attempted):** The `frontend/package.json` was updated to set `@vercel/kv` to "latest". This was an initial attempt to resolve the `kv.get` typing issue. Further steps (adding tsconfig.json and using `as any`) were also necessary.

These changes aim to ensure a successful build and deployment on Vercel.